### PR TITLE
Resolver Bug Results ViewModel

### DIFF
--- a/app/src/main/java/com/example/desafiofoton/MainActivity.kt
+++ b/app/src/main/java/com/example/desafiofoton/MainActivity.kt
@@ -58,6 +58,8 @@ class MainActivity : AppCompatActivity() {
             MovieResultsViewModelFactory(MovieRepository())
         ).get(MovieResultsViewModel::class.java)
 
+        viewModel.updateMovies()
+
         viewModel.movies.observe(this, { list ->
             binding.progressbar.visibility = View.GONE
             binding.loadMore.visibility = View.VISIBLE

--- a/app/src/main/java/com/example/desafiofoton/viewmodel/MovieResultsViewModel.kt
+++ b/app/src/main/java/com/example/desafiofoton/viewmodel/MovieResultsViewModel.kt
@@ -17,12 +17,6 @@ class MovieResultsViewModel(repository: MovieRepository) : ViewModel() {
     private val _movies = MutableLiveData<List<Movie>>()
     val movies : MutableLiveData<List<Movie>> = _movies
 
-    init {
-        viewModelScope.launch {
-            updateMovies()
-        }
-    }
-
     fun updateMovies() {
         _repository.getPopular(_page).enqueue(object : Callback<MovieResults> {
             override fun onResponse(


### PR DESCRIPTION
A activity de buscar filmes utiliza o mesmo viewModel que a activity main.
O viewModel tinha um bloco de inicialização que carregava os filmes populares, gerando inconsistências na activity de busca.